### PR TITLE
Amend README nix installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,15 @@
 # Install
 
 ```nix
-with import <nixpkgs> {};
-fetchSubmodules = true;
-let
-  tcrdd = callPackage (fetchFromGitHub {
-    owner = "FaustXVI";
-    repo = "tcrdd";
-    fetchSubmodules = true;
-    rev= "...";
-    sha256 = "...";
-  }) {};
-in stdenv.mkDerivation {
-    name = "...";
-    buildInputs = [
-        tcrdd
-    ];
-}
+{ pkgs ? import <nixpkgs> {}}:
+
+pkgs.callPackage (pkgs.fetchFromGitHub {
+  owner = "FaustXVI";
+  repo = "tcrdd";
+  fetchSubmodules = true;
+  rev= "...";
+  sha256 = "...";
+}) {}
 ```
 
 # Usage


### PR DESCRIPTION
Hello, just a tiny commit to amend the README nix example. I tried it and it did not work out of the box for me. This nix expression, pasted in a `tcrdd.nix` file worked when I installed it with `nix-env`.  I hope this can help people try this tool :)